### PR TITLE
update-base-URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: "Ilios"
 email: support@iliosproject.org
 description: Curriculum Management for the Health Professions
 baseurl: ""
-url: "https://ilios.github.io"
+url: "https:/iliosproject.org"
 github_username:  ilios
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
update our base url from the old github.io, to allow correct RSS subscription