### PR TITLE
Add a browser support matrix for ilios

### DIFF
--- a/technology.md
+++ b/technology.md
@@ -7,6 +7,14 @@ redirect_from: '/tech-specs/'
 
 ---
 
+__Supported Browsers__
+
+Chrome | Firefox ESR | Edge | Safari | Android | Safari iOS |
+--- | --- | --- | --- | --- | --- |
+![Chrome](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/chrome/chrome_48x48.png) | ![Firefox](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/firefox/firefox_48x48.png) | ![Edge](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/edge/edge_48x48.png) | ![Safari](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari/safari_48x48.png) | ![Android](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/android/android_48x48.png) | ![Safari iOS](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari-ios/safari-ios_48x48.png)
+Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ |
+
+
 __Current (as of 8/2016) Recommended Minimum System Requirements for Ilios 3 Installation:__
 
 Standard production-grade Linux or Windows server with at least 500GB of storage available (for learning materials storage):

--- a/technology.md
+++ b/technology.md
@@ -9,10 +9,10 @@ redirect_from: '/tech-specs/'
 
 __Supported Browsers__
 
-Chrome | Firefox ESR | Edge | Safari | Android | Safari iOS |
---- | --- | --- | --- | --- | --- |
-![Chrome](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/chrome/chrome_48x48.png) | ![Firefox](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/firefox/firefox_48x48.png) | ![Edge](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/edge/edge_48x48.png) | ![Safari](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari/safari_48x48.png) | ![Android](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/android/android_48x48.png) | ![Safari iOS](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari-ios/safari-ios_48x48.png)
-Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ |
+Chrome || Firefox ESR || Edge || Safari || Android || Safari iOS |
+--- | ---| --- | ---| --- | ---| --- | ---| --- | ---| --- |
+![Chrome](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/chrome/chrome_48x48.png) || ![Firefox](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/firefox/firefox_48x48.png) || ![Edge](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/edge/edge_48x48.png) || ![Safari](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari/safari_48x48.png) || ![Android](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/android/android_48x48.png) || ![Safari iOS](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari-ios/safari-ios_48x48.png)
+Latest ✔ || Latest ✔ || Latest ✔ || Latest ✔ || Latest ✔ || Latest ✔ |
 
 
 __Current (as of 8/2016) Recommended Minimum System Requirements for Ilios 3 Installation:__


### PR DESCRIPTION
Clearly indicate that we only support the latest version of these evergreen browsers.

This is a companion to https://github.com/ilios/frontend/pull/3105 where this change is actually made in the code. I have intentionally left IE 11 off of our list of supported browsers as it is not evergreen and is very unlikely to support new features. As it will be included in Windows until 2025 I don't want to stall our ability to deliver a great application by attempting to support that browser for another 8 years. In any case the global market share for IE 11 is under 5% and continues to drop so I don't think this is going to be an impactful change.