### PR TITLE
fix: correct date in post

### DIFF
--- a/_posts/2017-07-18-updates.markdown
+++ b/_posts/2017-07-18-updates.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tips & Tricks
-date: 2017-06-29  01:00:00
+date: 2017-07-18 01:00:00
 categories: updates
 ---
 


### PR DESCRIPTION
`jekyll build` is reporting that two posts are ending up in the same
file. Fixing the date on one of them fixes the problem.