### PR TITLE
root-level markdown linting fixes

### DIFF
--- a/404.md
+++ b/404.md
@@ -4,6 +4,7 @@ title: 404 Not Found
 permalink: /404.html
 pageClass: 'fourOhFour'
 ---
-#404: Rats! I couldn't find that.
+
+\#404: Rats! I couldn't find that.
 
 ![Funny Lost Cat](/assets/lostcat.png)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,28 +1,27 @@
 # Ilios Code of Conduct
 
-The Ilios team and community is made up of a mixture of professionals and 
-volunteers from all over the world, working on every aspect of the mission 
-- including mentorship, teaching, and connecting people.
+The Ilios team and community is made up of a mixture of professionals and
+volunteers from all over the world, working on every aspect of the mission
+-- including mentorship, teaching, and connecting people.
 
 Diversity is one of our huge strengths, but it can also lead to communication
 issues and unhappiness. To that end, we have a few ground rules that we ask
-people to adhere to. This code applies equally to contributors, mentors, 
+people to adhere to. This code applies equally to contributors, mentors,
 and those seeking help and guidance.
 
 This isn’t an exhaustive list of things that you can’t do. Rather, take it in
 the spirit in which it’s intended - a guide to make it easier to enrich all of
 us and the technical communities in which we participate.
 
-This code of conduct applies to all spaces managed by the Ilios project. 
-This includes the Slack workspace, the mailing lists, the issue tracker, 
-events, and any other forums created by the project team which the community 
-uses for communication. In addition, violations of this code outside 
+This code of conduct applies to all spaces managed by the Ilios project.
+This includes the Slack workspace, the mailing lists, the issue tracker,
+events, and any other forums created by the project team which the community
+uses for communication. In addition, violations of this code outside
 these spaces may affect a person's ability to participate within them.
 
 If you believe someone is violating the code of conduct, we ask that you
 report it by emailing
 [conduct@iliosproject.org](mailto:conduct@iliosproject.org).
-
 
 - **Be friendly and patient.**
 
@@ -73,6 +72,7 @@ This text is an adoption of the Code of Conduct provided by the
 [Django Software Foundation](https://www.djangoproject.com/conduct/).
 
 ## Questions?
+
 If you have questions, feel free to [contact us](mailto:info@iliosproject.org).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
+<!-- markdownlint-disable MD041 -->
+
 [![Netlify Status](https://api.netlify.com/api/v1/badges/c57a716e-4f40-4d77-8496-747a6eb50470/deploy-status)](https://app.netlify.com/sites/iliosproject/deploys)
 
 ## About
 
-This is the codebase for the Ilios Project Website at https://www.iliosproject.org
+This is the codebase for the Ilios Project Website at [https://www.iliosproject.org](https://www.iliosproject.org).
 
 ## Development
 
 For developing locally, we recommend using Docker with the provided Dockerfile.
 
 ### Requirements
+
 To use Docker, you will need to have [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed on your system, and you will need to add the path to the iliosproject.org codebase (this folder!) to your docker configuration by visiting `Resources -> File Sharing` in your Docker Desktop Settings and adding the path there. See below for more info...
 
 ### Get the code
 
-Clone the code from https://github.com/ilios/iliosproject.org - NOTE: you must have a Github username and password with proper permissions to clone code from this repository:
+Clone the code from [https://github.com/ilios/iliosproject.org](https://github.com/ilios/iliosproject.org) - NOTE: you must have a Github username and password with proper permissions to clone code from this repository:
 
 ```bash
 git clone git@github.com:/ilios/iliosproject.org
@@ -24,47 +27,55 @@ When the code is checked out, change into the newly-created `iliosproject.org` d
 ```bash
 cd iliosproject.org
 ```
+
 You are now in the codebase directory from where all of the rest of the following commands will be run.  To see the full path of the codebase directory you are in, run `pwd` to get the `Present Working Directory` path:
 
 ```bash
 pwd
 ```
+
 This is your codebase directory path. Make sure that the path displayed here is added as a "Shared folder" in your Docker Desktop settings. Open your Docker Desktop settings and go to `Resources -> File Sharing` and select `Create Share +` and browse to and select your codebase folder.
 
 ### Steps to run Docker
 
 1. From within the iliosproject.org codebase directory, run the following command to build the docker image locally:
-```bash
-docker build --no-cache -t iliosproject .
-```
+
+   ```bash
+   docker build --no-cache -t iliosproject .
+   ```
 
 2. Continuing from within the same directory, run the docker image:
-```bash
-docker run --rm --name iliosproject -p 4000:4000 -v .:/srv/app -i -t iliosproject
-```
 
-When the Docker container starts, it will build the iliosproject.org website locally, and will let you know when it is ready. When the container is fully started, you can visit your local site in your browser by visiting http://localhost:4000.
+   ```bash
+   docker run --rm --name iliosproject -p 4000:4000 -v .:/srv/app -i -t iliosproject
+   ```
+
+   When the Docker container starts, it will build the iliosproject.org website locally, and will let you know when it is ready. When the container is fully started, you can visit your local site in your browser by visiting [http://localhost:4000](http://localhost:4000).
 
 3. When you are done editing the code as-needed and would like to stop the iliosproject container, press `CTRL-C` in the same terminal window that is running the docker image, and then the following command:
-```bash
-docker stop iliosproject
-```
+
+   ```bash
+   docker stop iliosproject
+   ```
 
 When the container is completely stopped, you will see that the Jekyll process in your terminal window has now exited cleanly.
 
 When you are ready to work on the iliosproject.org codebase again, do a `git pull` and repeat steps 1-3 above.
 
-
 ## Developing locally without using Docker
+
 To run the site locally using Jekyll, `ruby`, `gem` and `bundler` are assumed to be installed. If these packages already exist on your system, just do the following:
 
 First build the packages and dependencies:
+
 ```bash
 bundle install
 ```
 
 Then serve via Jekyll.
+
 ```bash
 bundle exec jekyll serve
 ```
-The site should now be available for viewing in your browser at http://localhost:4000
+
+The site should now be available for viewing in your browser at [http://localhost:4000](http://localhost:4000).

--- a/about.md
+++ b/about.md
@@ -4,31 +4,35 @@ title: About
 permalink: /about/
 topLevel: true
 ---
+<!-- markdownlint-disable MD033 -->
 
 - [Technology](/technology)
 - [License](/license)
 - [Ilios Schools](/ilios-schools)
 - [Features](/features)
 
-<br>
-  <hr>
-<br>
+&nbsp;
+
+---
+
+&nbsp;
 
 _**The Ilios Vision**: To provide the Health Professions a user-friendly, flexible, and robust web application to collect, manage, analyze and deliver curricular information, which will continue to grow and adapt to new and changing models of Health Professions education._
 
 _**The Ilios Mission**: To be the premier provider of open source curriculum management to health professions schools around the globe, and to create and support a vibrant community of educators, technologists, and end users in the improvement and enhancement of education through curricular mapping, management, and delivery._
 
-<br>
- <hr>
-<br>
-<br>
-<br>
+&nbsp;
 
+---
 
+&nbsp;
+&nbsp;
+&nbsp;
 
 Ilios is a curriculum management platform for the Health Professions educational community. It is a user-friendly, flexible, and robust web application. Ilios collects, manages, analyzes, and delivers curricular information.
 
 Built by and for the health professions, Ilios supports the sharing of curriculum outcomes and materials among programs, departments, schools and institutions, while maintaining the flexibility to accommodate the unique practices within our diverse health professions community.
+
 - **ROBUST**: Ilios provides a flexible yet structured model for mapping your curriculum across all years of training.
 - **MULTI-SCHOOL**: A single Ilios deployment provides for any number of locations or campuses, regardless of distinction in curricula.
 - **MULTI-DISCIPLINARY**: Ilios allows for the creation and development of curricular material structured across any number of disciplines and programs.
@@ -36,10 +40,10 @@ Built by and for the health professions, Ilios supports the sharing of curriculu
 - **STANDARDS COMPLIANT**: Ilios is built to meet the MedBiquitous and AAMC specifications for Health Professions Curriculum standards.
 - **OPEN SOURCE**: Ilios is the only open source curriculum management application that adheres to the Medbiquitous curriculum inventory standard and was an early and continuous supporter for the 2011 - 2022 AAMC Curriculum Inventory report process.
 
-*Mapping and Managing:* Ilios creates a comprehensive view of curricula by tracking events, learning content and activities over time. The system facilitates day-to-day administration and the delivery of information to learners; enhances curricular development, review and innovation; and reduces overhead for internal and accreditation reporting. The end result is a powerful tool creating complete and accurate pictures of complex, integrated, multi-year curricula.
+_Mapping and Managing:_ Ilios creates a comprehensive view of curricula by tracking events, learning content and activities over time. The system facilitates day-to-day administration and the delivery of information to learners; enhances curricular development, review and innovation; and reduces overhead for internal and accreditation reporting. The end result is a powerful tool creating complete and accurate pictures of complex, integrated, multi-year curricula.
 
-*User Assignment & Access:* Ilios manages learners and instructors and their relationships to curricular materials and activities, enabling the tracking of educational hours, roles and role transitions for participants both internal and external to an institution. Ilios also provides a robust, scalable delivery mechanism for user-centric calendar and scheduling information, with direct access to critical course information, materials, and other educational systems and services.
+_User Assignment & Access:_ Ilios manages learners and instructors and their relationships to curricular materials and activities, enabling the tracking of educational hours, roles and role transitions for participants both internal and external to an institution. Ilios also provides a robust, scalable delivery mechanism for user-centric calendar and scheduling information, with direct access to critical course information, materials, and other educational systems and services.
 
-*Integration and Communication:* Ilios leverages the power of your existing online learning. With its comprehensive API, Ilios allows you to integrate with external data sources and systems. For schools using online learning systems such as Moodle or Canvas, Ilios provides a backbone of curricular information to make that deployment more robust and to complement the rich online tools, activities and materials already in use.
+_Integration and Communication:_ Ilios leverages the power of your existing online learning. With its comprehensive API, Ilios allows you to integrate with external data sources and systems. For schools using online learning systems such as Moodle or Canvas, Ilios provides a backbone of curricular information to make that deployment more robust and to complement the rich online tools, activities and materials already in use.
 
 <iframe src="//www.slideshare.net/slideshow/embed_code/key/9m4pN88tNImDHA" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/saschaben/updated-infodeck" title="Ilios Intro Info 2017" target="_blank">Ilios Intro Info 2017</a> </strong> from <strong><a target="_blank" href="//www.slideshare.net/saschaben">Sascha Cohen</a></strong> </div>

--- a/contact-us.md
+++ b/contact-us.md
@@ -4,13 +4,14 @@ title: Contact Us
 permalink: /contact/
 topLevel: true
 redirect_from: '/contact-us/'
-
 ---
+<!-- markdownlint-disable MD033 -->
+
 For more information on Ilios please contact:
 
-***The Ilios Project***  <br>
-UCSF School of Medicine & Library  <br>
-530 Parnassus Box 0840 <br>
+***The Ilios Project***\
+UCSF School of Medicine & Library\
+530 Parnassus Box 0840\
 San Francisco, CA 94143
 
 [info@iliosproject.org](mailto:info@iliosproject.org)
@@ -23,33 +24,32 @@ If you would like to be added to the Ilios monthly status updates and release no
 
 If you are a current institutional Ilios user, and require assistance or advice regarding your installation, please email us at [support@iliosproject.org](mailto:support@iliosproject.org?subject=SupportRequest).
 
-
 <!-- Begin MailChimp Signup Form -->
 <link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">
 <style type="text/css">
-	#mc_embed_signup{border: 1 black solid; clear:left; font:12px Helvetica,Arial,sans-serif; }
+  #mc_embed_signup{border: 1 black solid; clear:left; font:12px Helvetica,Arial,sans-serif; }
 </style>
 <div id="mc_embed_signup">
 <form action="//iliosproject.us3.list-manage.com/subscribe/post?u=845c4ebabb5b5ae7a6372c715&amp;id=1493e3df18" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
-	<h2>Subscribe to Ilios Status Updates and News!</h2>
+  <h2>Subscribe to Ilios Status Updates and News!</h2>
 <div class="mc-field-group">
-	<label for="mce-EMAIL">Email Address </label>
-	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+  <label for="mce-EMAIL">Email Address </label>
+  <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
 </div>
 <div class="mc-field-group">
-	<label for="mce-FNAME">First Name </label>
-	<input type="text" value="" name="FNAME" class="" id="mce-FNAME">
+  <label for="mce-FNAME">First Name </label>
+  <input type="text" value="" name="FNAME" class="" id="mce-FNAME">
 </div>
 <div class="mc-field-group">
-	<label for="mce-LNAME">Last Name </label>
-	<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
+  <label for="mce-LNAME">Last Name </label>
+  <input type="text" value="" name="LNAME" class="" id="mce-LNAME">
 </div>
 <!--- <p><a href="http://us3.campaign-archive2.com/home/?u=845c4ebabb5b5ae7a6372c715&id=1493e3df18" title="View previous campaigns">View previous campaigns.</a></p> --->
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+  <div id="mce-responses" class="clear">
+    <div class="response" id="mce-error-response" style="display:none"></div>
+    <div class="response" id="mce-success-response" style="display:none"></div>
+  </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
     <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_845c4ebabb5b5ae7a6372c715_1493e3df18" tabindex="-1" value=""></div>
     <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
     </div>

--- a/demo.md
+++ b/demo.md
@@ -6,9 +6,9 @@ topLevel: false
 ---
 
 The Ilios Demo site is available at [https://ilios-demo.ucsf.edu](https://ilios3-demo.ucsf.edu){:target="_blank"}.
- 
+
 This demo site serves multiple purposes. First, it provides a live location for potential users to explore and understand the Ilios application; second, it is our sample of just how Ilios can live as a secure, cloud hosted curriculum management tool; finally,since it is being fully populated with curricular data from the UCSF, it allows interested parties to review and analyze the current curriculum in place at UCSF and how that is being represented in Ilios, organized in the competency framework model, and presented to our learners.
- 
+
 Please contact us via [support@iliosproject.org](mailto:support@iliosproject.org) to request a user name, password, and access instructions.
 
 <!--EndFragment-->

--- a/features.md
+++ b/features.md
@@ -6,7 +6,7 @@ topLevel: false
 ---
 Ilios allows for the control and development of complex curricula organized by individual departments, programs schools or institutions. Courses may be shared across these organizations, while still maintaining data integrity, security and intellectual property controls.
 
-**Program Management**
+## Program Management
 
 - Create and manage any number of unique programs within your authorized institution(s)
 - Longitudinal tracking: control the attributes and requirements of each unique program year by year, allowing growth and modification to each individual matriculation group.
@@ -17,7 +17,7 @@ Ilios allows for the control and development of complex curricula organized by i
 
 &nbsp;
 
-**Group Management**
+## Group Management
 
 - Create and manage groups and sub-groups of learners for your curriculum
 - Add any person in the system to an instructor group and designate their role or classification
@@ -31,7 +31,7 @@ Ilios allows for the control and development of complex curricula organized by i
 
 &nbsp;
 
-**Course Management**
+## Course Management
 
 - Create and manage any number of courses and course events for your curriculum
 - Associate discrete learning objectives to courses and learning activities
@@ -45,7 +45,7 @@ Ilios allows for the control and development of complex curricula organized by i
 
 &nbsp;
 
-**Calendar Management**
+## Calendar Management
 
 - User-centric calendar access to all registered users
 - Multi-modal calendar search
@@ -55,7 +55,7 @@ Ilios allows for the control and development of complex curricula organized by i
 
 &nbsp;
 
-**User & ID Management**
+## User & ID Management
 
 - Import external feeds for enrollment and identity control
 - Export internal data for enrollment to 3rd party applications
@@ -64,7 +64,7 @@ Ilios allows for the control and development of complex curricula organized by i
 
 &nbsp;
 
-**Workflow Management**
+## Workflow Management
 
 - Easy control of materials for editing, review, and publishing/propagation
 - User control over who may move any piece of work from one state to the next, ie. draft to published
@@ -72,7 +72,7 @@ Ilios allows for the control and development of complex curricula organized by i
 
 &nbsp;
 
-**Data Tracking and Reporting**
+## Data Tracking and Reporting
 
 - Full relational data reporting capacity via API
 - Teaching hours tracking and management by instructor, department, educational method

--- a/forums.md
+++ b/forums.md
@@ -4,6 +4,7 @@ title: Forums (Closed Permanaently)
 permalink: /forums/
 topLevel: false
 ---
+<!-- markdownlint-disable MD033 -->
 
 ## We have closed our Ilios forums.  The best place to ask questions is in our [Slack Room](https://ilios-slack.herokuapp.com/)
 

--- a/hosting-pricing.md
+++ b/hosting-pricing.md
@@ -6,43 +6,44 @@ topLevel: false
 ---
 
 [<-- Back](/hosting)
-# __We Can Host You__
 
-Our hosting service begins for as little as **$1,000 per month**, per school.
+## We Can Host You
+
+Our hosting service begins for as little as __$1,000 per month__, per school.
 
 Implementation, customization, and deployment fees are separate and not included.
 
 If you are interested, please [contact us](mailto:info@iliosproject.org) for further  details.
 
-<br>
+&nbsp;
 
 PRICE LIST (as of 9/01/2019)
 
 ||
-| SYSTEM APPLICATION |PRICE (annual) |
+| SYSTEM APPLICATION | PRICE (annual) |
 |:-------------------|--------------:|
 |||
-| _Core Services_	 ||
-| One-time Implementation fee (_req._) | _$15,000.00_
-| Core Hosting Services: | _$12,000.00_|
+| _Core Services_ ||
+| One-time Implementation fee (_req._) | _$15,000.00_ |
+| Core Hosting Services: | _$12,000.00_ |
 |||
- _Additional Services_ ||
-| LTI Component Activation| _(one-time fee) $500.00_|
-| Custom Development| _TBD: starting at $185/hr_ |
-| Mirror test / stage environment|	_$10,200 ($850/mo)_|
-| Custom Update Schedule|	_Inquire_|
+| _Additional Services_ ||
+| LTI Component Activation | _(one-time fee) $500.00_ |
+| Custom Development | _TBD: starting at $185/hr_ |
+| Mirror test / stage environment | _$10,200 ($850/mo)_ |
+| Custom Update Schedule| _Inquire_ |
 |||
 | _Other Services_ ||
-|DB Backups|	_Included_|
-|LM Backups|	_Included_|
-|Additional Storage|	_Included_|
-|Load Balancing & failover|	_Included_|
-|Audit logs|	_Included_|
-|Multi-zone redundancy|	_Included_|
+| DB Backups | _Included_ |
+| LM Backups | _Included_ |
+| Additional Storage | _Included_ |
+| Load Balancing & failover | _Included_ |
+| Audit logs | _Included_ |
+| Multi-zone redundancy | _Included_ |
 |||
 | _Training_ ||
-|Onsite training - 2 days|	_startnig at $13,800.00_|
-|Virtual Online training - 2 days|	_starting at 8,500.00_|
-||
+| Onsite training - 2 days | _starting at $13,800.00_ |
+| Virtual Online training - 2 days | _starting at 8,500.00_ |
+|||
 
 ![Ilios-AWS-Schema](https://gallery.mailchimp.com/845c4ebabb5b5ae7a6372c715/images/b70aa30e-0d9a-4bf6-af9b-ce25adfa7454.png)

--- a/hosting.md
+++ b/hosting.md
@@ -4,11 +4,11 @@ title: Hosting
 permalink: /hosting/
 topLevel: false
 ---
-# __We Can Host You__
+
+## We Can Host You
 
 If you are interested in having us host your Ilios instance for you in our secure production environment, let us know. We can help migrate your existing Ilios, or if you are new to Ilios we can spin you up an original setup. Our pricing is competitive (your entire institution can run Ilios for about the [cost of daily parking](/parking-pricing)), and our goal is to keep costs as low as possible for you -- based on our own bare-bones AWS costs of service. [**_See Sample Pricing_**](/hosting-pricing)
 
 Get automatic upgrades, always current releases, and the security of knowing that your servers are being managed by the core Ilios team! Please [contact us](mailto:info@iliosproject.org) for pricing, details, and more info.
-
 
 ![Ilios-AWS-Schema](https://gallery.mailchimp.com/845c4ebabb5b5ae7a6372c715/images/b70aa30e-0d9a-4bf6-af9b-ce25adfa7454.png)

--- a/ilios-schools.md
+++ b/ilios-schools.md
@@ -37,7 +37,7 @@ If you are interested in joining the Ilios Project Consortium as a contributing 
 
 Ilios is an Open Source, community-based software application. For more information on Ilios please contact:
 
-*The Ilios Project* <br>
-UCSF School of Medicine & Library <br>
-530 Parnassus Box 0840 <br>
+*The Ilios Project*\
+UCSF School of Medicine & Library\
+530 Parnassus Box 0840\
 San Francisco, CA 94143

--- a/index.md
+++ b/index.md
@@ -2,14 +2,15 @@
 layout: page
 redirect_from: '/home/'
 path: '/'
-
 ---
+<!-- markdownlint-disable MD033 MD041 -->
 
 {% assign post = site.posts.first %}
 {% assign content = post.content %}
 
 # Ilios: Curriculum Management *from* UCSF
-#### - The premier open source curriculum management platform for schools around the globe -
+
+The premier open source curriculum management platform for schools around the globe
 
 - [Ilios Hosting - **Get Hosted!**](/hosting)
 - [Ilios In House - **Get The Code!**](https://www.github.com/ilios/ilios/releases/latest/){:target="_blank"}
@@ -18,7 +19,6 @@ path: '/'
 - [Latest User Guide](https://iliosproject.gitbooks.io/ilios-user-guide/content/){:target="_blank"} *(always up to date!)*
   - [Read the FAQs](https://github.com/ilios/ilios/wiki/FAQS){:target="_blank"}
   - [Check out our Wiki](https://github.com/ilios/ilios/wiki){:target="_blank"}
-
 
 ## Latest News
 

--- a/myreports.md
+++ b/myreports.md
@@ -4,8 +4,7 @@ title: My Reports
 permalink: /myreports.html
 topLevel: false
 ---
-
-
+<!-- markdownlint-disable MD033 -->
   <title>Ilios My Reports Grid</title>
   <style type="text/css">
    ol{margin:0;padding:0}
@@ -48,9 +47,7 @@ topLevel: false
    h6{padding-top:10pt;line-height:1.15;text-align:left;color:#000000;font-size:10pt;font-family:"Arial";font-weight:bold;padding-bottom:2pt}
    </style>
 
-
-
- <p class="c6 c9">
+  <p class="c6 c9">
 
   <span class="c1"></span>
  </p><a href="#" name="71619b3b69cc506a5e38b4fbb8c4104ee8834b2a"></a><a href="#" name="0"></a>
@@ -59,7 +56,7 @@ topLevel: false
  <tbody>
   <tr>
    <td class="c8 c22">
-    <p class="c0"><span class="c1">&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;HAVING</span><img height="28" src="/media/image01.png" width="96"><br /><span class="c1">GET ALL &nbsp; </span></p>
+    <p class="c0"><span class="c1">&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;HAVING</span><img height="28" src="/media/image01.png" width="96" alt=""><br /><span class="c1">GET ALL &nbsp; </span></p>
    </td>
   <td class="c3 c8"><p class="c0 c14"><span class="c11 c15">Course</span></p></td>
   <td class="c3 c8"><p class="c0 c14"><span class="c11 c15">Session</span></p></td>
@@ -278,7 +275,7 @@ topLevel: false
   <table cellpadding="0" cellspacing="0" class="c12">
    <tbody>
     <tr>
-     <td class="c13"><p class="c0"><img height="113" src="/media/image00.png" width="298"></p></td>
+     <td class="c13"><p class="c0"><img height="113" src="/media/image00.png" width="298" alt=""></p></td>
      <td class="c25"><p class="c6 c9"><span class="c1"></span></p>
       <p class="c9"><span class="c11 c1">(C)</span><span class="c1">&nbsp; &nbsp; &nbsp; = Course Only</span></p>
       <p class="c9"><span class="c11 c1">(S)</span><span class="c1">&nbsp; &nbsp; &nbsp; &nbsp;= Session Only</span></p>

--- a/news.md
+++ b/news.md
@@ -4,6 +4,7 @@ title: News
 permalink: /news/
 topLevel: true
 ---
+<!-- markdownlint-disable MD033 -->
 
 <div class="subscribe-for-updates">
   <a href="/subscribe">Subscribe for Updates</a>
@@ -16,7 +17,7 @@ topLevel: true
       <h2>
         <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
       </h2>
-      
+
       {{post.excerpt}}
     </li>
   {% endfor %}

--- a/parking-pricing.md
+++ b/parking-pricing.md
@@ -6,13 +6,13 @@ topLevel: false
 ---
 
 [<-- Back](/hosting)
-# __We Can Host You__
+
+## We Can Host You
 
 For $32 a day, you can either park one car in the lot, or have your whole school running Ilios:
 
 ![parking_prices](https://gallery.mailchimp.com/845c4ebabb5b5ae7a6372c715/images/a4ce7746-128e-48b0-9fe0-7691bc94d6ee.png)
 
-<br>
-
+&nbsp;
 
 ![Ilios-AWS-Schema](https://gallery.mailchimp.com/845c4ebabb5b5ae7a6372c715/images/b70aa30e-0d9a-4bf6-af9b-ce25adfa7454.png)

--- a/subscribe.md
+++ b/subscribe.md
@@ -4,38 +4,40 @@ title: Subscribe
 permalink: /subscribe/
 topLevel: false
 ---
+<!-- markdownlint-disable MD033 -->
 
 ***NEW***: You can now contact us on Slack! Join the channel here: [https://ilios-slack.herokuapp.com/](https://ilios-slack.herokuapp.com/){:target="_blank"}
 
 If you would like to be added to the Ilios monthly status updates and release notice distribution list, please add your name and email to our subscriber lists using the form below:
+
 <!-- Begin MailChimp Signup Form -->
 <link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">
 <style type="text/css">
-	#mc_embed_signup{border: 1 black solid; clear:left; font:12px Helvetica,Arial,sans-serif; }
+  #mc_embed_signup{border: 1 black solid; clear:left; font:12px Helvetica,Arial,sans-serif; }
 </style>
 <div id="mc_embed_signup">
 <form action="//iliosproject.us3.list-manage.com/subscribe/post?u=845c4ebabb5b5ae7a6372c715&amp;id=1493e3df18" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
-	<h2>Subscribe to Ilios Status Updates and News!</h2>
+  <h2>Subscribe to Ilios Status Updates and News!</h2>
 <div class="mc-field-group">
-	<label for="mce-EMAIL">Email Address </label>
-	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+  <label for="mce-EMAIL">Email Address </label>
+  <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
 </div>
 <div class="mc-field-group">
-	<label for="mce-FNAME">First Name </label>
-	<input type="text" value="" name="FNAME" class="" id="mce-FNAME">
+  <label for="mce-FNAME">First Name </label>
+  <input type="text" value="" name="FNAME" class="" id="mce-FNAME">
 </div>
 <div class="mc-field-group">
-	<label for="mce-LNAME">Last Name </label>
-	<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
+  <label for="mce-LNAME">Last Name </label>
+  <input type="text" value="" name="LNAME" class="" id="mce-LNAME">
 </div>
 <!--- <p><a href="http://us3.campaign-archive2.com/home/?u=845c4ebabb5b5ae7a6372c715&id=1493e3df18" title="View previous campaigns">View previous campaigns.</a></p> --->
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_845c4ebabb5b5ae7a6372c715_1493e3df18" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+  <div id="mce-responses" class="clear">
+    <div class="response" id="mce-error-response" style="display:none"></div>
+    <div class="response" id="mce-success-response" style="display:none"></div>
+  </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+  <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_845c4ebabb5b5ae7a6372c715_1493e3df18" tabindex="-1" value=""></div>
+  <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
     </div>
 </form>
 </div>

--- a/technology.md
+++ b/technology.md
@@ -7,13 +7,12 @@ redirect_from: '/tech-specs/'
 
 ---
 
-__Supported Browsers__
+## Supported Browsers
 
 Chrome || Firefox ESR || Edge || Safari || Safari iOS |
 --- | ---| --- | ---| --- | ---| --- | ---| --- | ---| --- |
 ![Chrome](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/chrome/chrome_48x48.png) || ![Firefox](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/firefox/firefox_48x48.png) || ![Edge](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/edge/edge_48x48.png) || ![Safari](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari/safari_48x48.png) || ![Safari iOS](https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari-ios/safari-ios_48x48.png)
 Latest ✔ || Latest ✔ || Latest ✔ || Latest ✔ || Latest ✔ |
-
 
 __Current (as of 3/2022) Recommended Minimum System Requirements for Ilios 3 Installation:__
 

--- a/timeline.md
+++ b/timeline.md
@@ -4,22 +4,22 @@ title: Timeline
 permalink: /timeline/
 topLevel: true
 ---
+<!-- markdownlint-disable MD033 -->
+
 #### **Past Progress:**
 
-> **_2010_** : Functional first-generation software application deployed.  
-**_2013_** : *Refinement and expansion* of the product, and outreach to the larger community.  
-**_2015_** : *Support and expansion* of the Open Source Community   
-**_2016_** : Deployment of the *API-driven application platform*  
-**_2017_** : Implementation of *Mobile-Ready Interface*  
-**_2018_** : Introduction of *Curriculum-based Granular Permissions Matrix*  
-**_2019_** : Deployment of *Global Search for Ilios*  
+> **_2010_** : Functional first-generation software application deployed.\
+**_2013_** : _Refinement and expansion_ of the product, and outreach to the larger community.\
+**_2015_** : _Support and expansion_ of the Open Source Community\
+**_2016_** : Deployment of the _API-driven application platform_\
+**_2017_** : Implementation of _Mobile-Ready Interface_\
+**_2018_** : Introduction of _Curriculum-based Granular Permissions Matrix_\
+**_2019_** : Deployment of _Global Search for Ilios_
 
 #### **Current Roadmap:**
 
->**_2020_** - **_2022_** : Full (AA/AAA) accessibility; improved performance; personalization and preferences; site management; extended objective tagging; extended analytics
-
->(_2023_ - _2025_ : _Community engagement; next-generation planning and preparation; enhanced preferences and analytics_)
-
+> **_2020_** - **_2022_** : Full (AA/AAA) accessibility; improved performance; personalization and preferences; site management; extended objective tagging; extended analytics\
+> (_2023_ - _2025_ : _Community engagement; next-generation planning and preparation; enhanced preferences and analytics_)
 
 Since we began the Ilios Project in 2009, we have journeyed through multiple phases of growth and development. Beginning in 2015, we moved into the next critical phase of growth. During the expected 7-year lifecycle of version 3 (2016-2023), we will continue to extend and improve the application platform for mobility, interoperability and visibility of data across the spectrum of the educational ecosystem.
 


### PR DESCRIPTION
Went through all the root-level Markdown files and checked for [linting](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md) issues.

Fixed all issues except the following things:
* Ignored entirely
  * MD013 `line-length` (tons of lines are 'too long', but whatever)
* Ignored with comment
  * MD033 - `no-inline-html` (too much random HTML to change to pure Markdown, and probably isn't worth it)
  * MD041 - `first-line-h1` (there are a couple files that use something besides a heading at the beginning, which seems fine to me)