### PR TITLE
Site nav improvement

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,11 +26,11 @@
 
       <div class="trigger">
         <span class="page-link space-link">&nbsp;</span
-        ><a class="page-link {% if '/' == page.url %} active{% endif %}" href="/">Home</a>
+        ><a class="page-link{% if '/' == page.url %} active{% endif %}" href="/">Home</a>
         {% for nav in site.pages %} {% if nav.title and nav.topLevel %}
         <span class="page-link space-link">&nbsp;</span
         ><a
-          class="page-link {% if nav.url == page.url %} active{% endif %}"
+          class="page-link{% if nav.url == page.url %} active{% endif %}"
           href="{{ nav.url | prepend: site.baseurl }}"
           >{{ nav.title }}</a
         >

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,22 +25,20 @@
       </button>
 
       <div class="trigger">
-        <span class="page-link space-link">&nbsp;</span
-        ><a class="page-link{% if '/' == page.url %} active{% endif %}" href="/">Home</a>
+        <a class="page-link{% if '/' == page.url %} active{% endif %}" href="/">Home</a>
+
         {% for nav in site.pages %} {% if nav.title and nav.topLevel %}
-        <span class="page-link space-link">&nbsp;</span
-        ><a
+        <a
           class="page-link{% if nav.url == page.url %} active{% endif %}"
           href="{{ nav.url | prepend: site.baseurl }}"
           >{{ nav.title }}</a
         >
         {% endif %} {% endfor %}
-        <span class="page-link space-link">&nbsp;</span
-        ><a
+        <a
           class="page-link"
           href="http://us3.campaign-archive2.com/home/?u=845c4ebabb5b5ae7a6372c715&id=1493e3df18"
           target="_blank"
-          >Status&nbsp;Reports</a
+          >Status Reports</a
         >
       </div>
     </nav>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,215 +1,219 @@
-@use "sass:math";
+@use 'sass:math';
 
 /**
  * Reset some basic elements
  */
-body, h1, h2, h3, h4, h5, h6,
-p, blockquote, pre, hr,
-dl, dd, ol, ul, figure {
-    margin: 0;
-    padding: 0;
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+hr,
+dl,
+dd,
+ol,
+ul,
+figure {
+  margin: 0;
+  padding: 0;
 }
-
-
 
 /**
  * Basic styling
  */
 body {
-    font-family: $base-font-family;
-    font-size: $base-font-size;
-    line-height: $base-line-height;
-    font-weight: 300;
-    color: $text-color;
-    background-color: $background-color;
-    -webkit-text-size-adjust: 100%;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
+  line-height: $base-line-height;
+  font-weight: 300;
+  color: $text-color;
+  background-color: $background-color;
+  -webkit-text-size-adjust: 100%;
 }
-
-
 
 /**
  * Set `margin-bottom` to maintain vertical rhythm
  */
-h1, h2, h3, h4, h5, h6,
-p, blockquote, pre,
-ul, ol, dl, figure,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+ul,
+ol,
+dl,
+figure,
 %vertical-rhythm {
-    margin-bottom: calc($spacing-unit / 2);
+  margin-bottom: calc($spacing-unit / 2);
 }
-
 
 /**
  * Images
  */
 img {
-    max-width: 100%;
-    vertical-align: middle;
-    margin-bottom: 3px;
-    border-radius: 6px;
+  max-width: 100%;
+  vertical-align: middle;
+  margin-bottom: 3px;
+  border-radius: 6px;
 }
-
-
 
 /**
  * Figures
  */
 figure > img {
-    display: block;
+  display: block;
 }
 
 figcaption {
-    font-size: $small-font-size;
+  font-size: $small-font-size;
 }
-
-
 
 /**
  * Lists
  */
-ul, ol {
-    margin-left: $spacing-unit;
+ul,
+ol {
+  margin-left: $spacing-unit;
 }
 
 li {
-    > ul,
-    > ol {
-         margin-bottom: 0;
-    }
+  > ul,
+  > ol {
+    margin-bottom: 0;
+  }
 }
-
-
 
 /**
  * Headings
  */
-h1, h2, h3, h4, h5, h6 {
-    font-weight: 300;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 300;
 }
-
-
 
 /**
  * Links
  */
 a {
-    color: $brand-color;
-    text-decoration: none;
+  color: $brand-color;
+  text-decoration: none;
 
-    &:visited {
-        color: darken($brand-color, 15%);
-    }
+  &:visited {
+    color: darken($brand-color, 15%);
+  }
 
-    &:hover {
-        color: $text-color;
-        text-decoration: underline;
-    }
+  &:hover {
+    color: $text-color;
+    text-decoration: underline;
+  }
 }
-
-
 
 /**
  * Blockquotes
  */
 blockquote {
-    color: $grey-color;
-    border-left: 4px solid $grey-color-light;
-    padding-left: calc($spacing-unit / 2);
-    font-size: 18px;
-    letter-spacing: -1px;
-    font-style: italic;
+  color: $grey-color;
+  border-left: 4px solid $grey-color-light;
+  padding-left: calc($spacing-unit / 2);
+  font-size: 18px;
+  letter-spacing: -1px;
+  font-style: italic;
 
-    > :last-child {
-        margin-bottom: 0;
-    }
+  > :last-child {
+    margin-bottom: 0;
+  }
 }
-
-
 
 /**
  * Code formatting
  */
 pre,
 code {
-    font-size: 15px;
-    border: 1px solid $grey-color-light;
-    border-radius: 3px;
-    background-color: #eef;
+  font-size: 15px;
+  border: 1px solid $grey-color-light;
+  border-radius: 3px;
+  background-color: #eef;
 }
 
 code {
-    padding: 1px 5px;
+  padding: 1px 5px;
 }
 
 pre {
-    padding: 8px 12px;
-    overflow-x: scroll;
+  padding: 8px 12px;
+  overflow-x: scroll;
 
-    > code {
-        border: 0;
-        padding-right: 0;
-        padding-left: 0;
-    }
+  > code {
+    border: 0;
+    padding-right: 0;
+    padding-left: 0;
+  }
 }
-
-
 
 /**
  * Wrapper
  */
 .wrapper {
-    max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit} * 2));
-    max-width:         calc(#{$content-width} - (#{$spacing-unit} * 2));
-    margin-right: auto;
-    margin-left: auto;
-    padding-right: $spacing-unit;
-    padding-left: $spacing-unit;
-    @extend %clearfix;
+  max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit} * 2));
+  max-width: calc(#{$content-width} - (#{$spacing-unit} * 2));
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: $spacing-unit;
+  padding-left: $spacing-unit;
+  @extend %clearfix;
 
-    @include media-query($on-laptop) {
-        max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit}));
-        max-width:         calc(#{$content-width} - (#{$spacing-unit}));
-        padding-right: calc($spacing-unit / 2);
-        padding-left: calc($spacing-unit / 2);
-    }
+  @include media-query($on-laptop) {
+    max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit}));
+    max-width: calc(#{$content-width} - (#{$spacing-unit}));
+    padding-right: calc($spacing-unit / 2);
+    padding-left: calc($spacing-unit / 2);
+  }
 }
-
-
 
 /**
  * Clearfix
  */
 %clearfix {
-
-    &:after {
-        content: "";
-        display: table;
-        clear: both;
-    }
+  &:after {
+    content: '';
+    display: table;
+    clear: both;
+  }
 }
-
-
 
 /**
  * Icons
  */
 .icon {
+  > svg {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
 
-    > svg {
-        display: inline-block;
-        width: 16px;
-        height: 16px;
-        vertical-align: middle;
-
-        path {
-            fill: $grey-color;
-        }
+    path {
+      fill: $grey-color;
     }
+  }
 }
 
 article.post-content {
   @include css3-prefix('column-width', '300px');
   @include css3-prefix('column-gap', '2em');
-  @include css3-prefix('column-rule-width', "1px");
-  @include css3-prefix('column-rule-style', "solid");
+  @include css3-prefix('column-rule-width', '1px');
+  @include css3-prefix('column-rule-style', 'solid');
   @include css3-prefix('column-rule-color', $grey-color-light);
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -68,7 +68,7 @@
 
     // Gaps between nav items, but not on the first one
     &:not(:first-child) {
-      margin-left: 12px;
+      margin-left: 30px;
     }
 
     &.active {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -5,13 +5,17 @@
 .site-header {
   border-top: 5px solid $grey-color-dark;
   border-bottom: 1px solid $grey-color-light;
-  padding-left: 7em;
+  padding-left: 0;
   min-height: 68px;
   max-height: 68px;
   background-color: rgb(216, 91, 0);
 
   // Positioning context for the mobile navigation icon
   position: relative;
+
+  @include media-query($on-laptop) {
+    padding-left: 7em;
+  }
 }
 //adding this for the header tagline
 .site-header-tag {
@@ -47,8 +51,9 @@
 
 .site-nav {
   //   vertical-align: sub;
-  float: right;
-  line-height: 68px;
+  clear: both;
+  float: left;
+  line-height: 34px;
   z-index: 5;
 
   #menu-icon {
@@ -57,7 +62,9 @@
 
   .page-link {
     color: $text-color;
+    display: inline-block;
     line-height: $base-line-height;
+    margin-top: 1.5em;
 
     // Gaps between nav items, but not on the first one
     &:not(:first-child) {
@@ -78,8 +85,8 @@
 
   @include media-query($on-palm) {
     position: absolute;
-    top: 9px;
-    right: 30px;
+    top: 14px;
+    right: 14px;
     background-color: $background-color;
     border: 1px solid $grey-color-light;
     border-radius: 5px;
@@ -248,6 +255,7 @@
  * Posts
  */
 .post-header {
+  clear: both;
   margin-bottom: $spacing-unit;
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -23,6 +23,10 @@
   font-weight: bold;
   font-size: 12px;
   z-index: 1;
+
+  @include media-query($on-palm) {
+    display: none;
+  }
 }
 .site-title {
   font-size: 26px;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -22,7 +22,6 @@
   color: #ffffff;
   font-weight: bold;
   font-size: 12px;
-  align: right;
   z-index: 1;
 }
 .site-title {

--- a/css/main.scss
+++ b/css/main.scss
@@ -24,7 +24,7 @@ $grey-color-dark: darken($grey-color, 25%);
 $content-width: 800px;
 
 $on-palm: 600px;
-$on-laptop: 800px;
+$on-laptop: 1000px;
 
 // Using media queries with like this:
 // @include media-query($on-palm) {

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,33 +1,30 @@
 ---
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
+
 @charset "utf-8";
-
-
 
 // Our variables
 $base-font-family: Helvetica, Arial, sans-serif;
-$base-font-size:   16px;
-$small-font-size:  $base-font-size * 0.875;
+$base-font-size: 16px;
+$small-font-size: $base-font-size * 0.875;
 $base-line-height: 1.5;
 
-$spacing-unit:     30px;
+$spacing-unit: 30px;
 
-$text-color:       #111;
+$text-color: #111;
 $background-color: #fdfdfd;
-$brand-color:      #2a7ae2;
+$brand-color: #2a7ae2;
 
-$grey-color:       #828282;
+$grey-color: #828282;
 $grey-color-light: lighten($grey-color, 40%);
-$grey-color-dark:  darken($grey-color, 25%);
+$grey-color-dark: darken($grey-color, 25%);
 
 // Width of the content area
-$content-width:    800px;
+$content-width: 800px;
 
-$on-palm:          600px;
-$on-laptop:        800px;
-
-
+$on-palm: 600px;
+$on-laptop: 800px;
 
 // Using media queries with like this:
 // @include media-query($on-palm) {
@@ -37,17 +34,10 @@ $on-laptop:        800px;
 //     }
 // }
 @mixin media-query($device) {
-    @media screen and (max-width: $device) {
-        @content;
-    }
+  @media screen and (max-width: $device) {
+    @content;
+  }
 }
 
-
-
 // Import partials from `sass_dir` (defaults to `_sass`)
-@import
-        "mixins",
-        "base",
-        "layout",
-        "syntax-highlighting"
-;
+@import 'mixins', 'base', 'layout', 'syntax-highlighting';


### PR DESCRIPTION
* prettified some SCSS files
* removed space-links
* added some `clear: both` attributes to push things down properly
* site-title and site-header-tag now sit in line with content unless viewport is too small
* mobile nav icon re-positioned to better line up with content/nav
* increased laptop cutoff from 800 to 1000