### PR TITLE
Link updates

### DIFF
--- a/contact-us.md
+++ b/contact-us.md
@@ -16,7 +16,7 @@ San Francisco, CA 94143
 
 [info@iliosproject.org](mailto:info@iliosproject.org)
 
-You can now contact us on Slack! Join the channel here: [https://ilios-slack.herokuapp.com/](https://ilios-slack.herokuapp.com/){:target="_blank"}
+You can now contact us on Slack! Join the channel here: [https://team-ilios.slack.com/](https://team-ilios.slack.com/){:target="_blank"}
 
 Or if you wish, you may call the UCSF School of Medicine Office of Technology Enhanced Education at: (415) 502-2800.
 

--- a/demo.md
+++ b/demo.md
@@ -5,7 +5,7 @@ permalink: /demo/
 topLevel: false
 ---
 
-The Ilios Demo site is available at [https://ilios-demo.ucsf.edu](https://ilios3-demo.ucsf.edu){:target="_blank"}.
+The Ilios Demo site is available at [https://demo.iliosproject.org](https://demo.iliosproject.org){:target="_blank"}.
 
 This demo site serves multiple purposes. First, it provides a live location for potential users to explore and understand the Ilios application; second, it is our sample of just how Ilios can live as a secure, cloud hosted curriculum management tool; finally,since it is being fully populated with curricular data from the UCSF, it allows interested parties to review and analyze the current curriculum in place at UCSF and how that is being represented in Ilios, organized in the competency framework model, and presented to our learners.
 

--- a/forums.md
+++ b/forums.md
@@ -6,7 +6,7 @@ topLevel: false
 ---
 <!-- markdownlint-disable MD033 -->
 
-## We have closed our Ilios forums.  The best place to ask questions is in our [Slack Room](https://ilios-slack.herokuapp.com/)
+## We have closed our Ilios forums.  The best place to ask questions is in our [Slack Room](https://team-ilios.slack.com/)
 
 <script async defer src="https://ilios-slack.herokuapp.com/slackin.js"></script>
 

--- a/forums.md
+++ b/forums.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Forums (Closed Permanaently)
+title: Forums (Closed Permanently)
 permalink: /forums/
 topLevel: false
 ---

--- a/forums.md
+++ b/forums.md
@@ -8,6 +8,4 @@ topLevel: false
 
 ## We have closed our Ilios forums.  The best place to ask questions is in our [Slack Room](https://team-ilios.slack.com/)
 
-<script async defer src="https://ilios-slack.herokuapp.com/slackin.js"></script>
-
 ## Or on the [wiki entry](https://github.com/ilios/ilios/wiki)

--- a/subscribe.md
+++ b/subscribe.md
@@ -6,7 +6,7 @@ topLevel: false
 ---
 <!-- markdownlint-disable MD033 -->
 
-***NEW***: You can now contact us on Slack! Join the channel here: [https://ilios-slack.herokuapp.com/](https://ilios-slack.herokuapp.com/){:target="_blank"}
+***NEW***: You can now contact us on Slack! Join the channel here: [https://team-ilios.slack.com/](https://team-ilios.slack.com/){:target="_blank"}
 
 If you would like to be added to the Ilios monthly status updates and release notice distribution list, please add your name and email to our subscriber lists using the form below:
 


### PR DESCRIPTION
* Fixed some links that were pointing to a defunct Heroku Slack address and rerouted them to the correct one.
* Fixed a main section link to the demo site