### PR TITLE
rm malformed markup fragments from blog posts.

### DIFF
--- a/markdown/posts/2022-02-11-updates.md
+++ b/markdown/posts/2022-02-11-updates.md
@@ -5,10 +5,9 @@ date: 2022-02-11  08:00:00
 categories: updates
 ---
 
-| **CURRENT STATUS**:
-|Current Version: **v3.96.3**
-|Next Scheduled Release: _25 February 2022_
-|
+**CURRENT STATUS**:  
+Current Version: **v3.96.3**  
+Next Scheduled Release: _25 February 2022_
 
 **What does it take to maintain an Open Source Software platform like Ilios?**
 

--- a/markdown/posts/2022-03-15-updates.md
+++ b/markdown/posts/2022-03-15-updates.md
@@ -5,16 +5,14 @@ date: 2022-03-15  08:00:00
 categories: updates
 ---
 
-| **CURRENT STATUS**:
-|Current Version: **v3.97.0**
-|Next Scheduled Release: _25 March 2022_
-|
-|**CURRENT RELEASE HIGHLIGHTS**:
-| - My Materials consolidation and improvements
-| - Massive performance enhancements
-|
-|
-|
+**CURRENT STATUS**:  
+Current Version: **v3.97.0**  
+Next Scheduled Release: _25 March 2022_
+
+**CURRENT RELEASE HIGHLIGHTS**:
+
+- My Materials consolidation and improvements
+- Massive performance enhancements
 
 _DevOps Geek Note_: We are expecting to be moving the Ilios application to Ember 4 in late Spring 2022, which will provide more performance improvements, greater code stability, and some solid future-proofing for the application. More [here]([https://blog.emberjs.com/ember-4-0-released/]): [https://blog.emberjs.com/ember-4-0-released/](https://blog.emberjs.com/ember-4-0-released/)
 

--- a/markdown/posts/2022-06-06-updates.md
+++ b/markdown/posts/2022-06-06-updates.md
@@ -5,15 +5,14 @@ date: 2022-06-07  08:00:00
 categories: updates
 ---
 
-| **CURRENT STATUS**:
-| Current Version: **v3.99.1.0**
-| Next Scheduled Release: v3.100.0 planned _10 June 2022_
-|
-| **CURRENT RELEASE HIGHLIGHTS**:
-| - More massive performance enhancements
-| - UI improvements
-|
-|
+**CURRENT STATUS**:  
+Current Version: **v3.99.1.0**  
+Next Scheduled Release: v3.100.0 planned _10 June 2022_
+
+**CURRENT RELEASE HIGHLIGHTS**:
+
+- More massive performance enhancements
+- UI improvements
 
 EMBER 4 Status: As of v3.98.1, Ilios has moved to Ember 4, providing massive performance improvements (and room for more!). In coming releases, we'll see continued improvements including a shift in our caching strategy.
 

--- a/markdown/posts/2022-07-01-updates.md
+++ b/markdown/posts/2022-07-01-updates.md
@@ -5,13 +5,13 @@ date: 2022-07-01  08:00:00
 categories: updates
 ---
 
-| **CURRENT STATUS**:
-| Current Version: **v3.101.0**
-| Next Scheduled Release: _14 July 2022_
-|
-| **CURRENT RELEASE HIGHLIGHTS**: **SECURITY UPDATE**
-|
-|A bug was recently reported in Ilios which would allow an authenticated user to bypass some of the security controls and read data which they otherwise should not have been able to access. This was introduced in **v3.75.1**.
+**CURRENT STATUS**:  
+Current Version: **v3.101.0**  
+Next Scheduled Release: _14 July 2022_
+
+**CURRENT RELEASE HIGHLIGHTS**: **SECURITY UPDATE**
+
+A bug was recently reported in Ilios which would allow an authenticated user to bypass some of the security controls and read data which they otherwise should not have been able to access. This was introduced in **v3.75.1**.
 
 While this would not have allowed access from a member of the public or any unauthenticated user, it could have allowed a student to access data about other students including their email address and schedule. This could occur as a result of the accidental sharing of a non-public URL.
 

--- a/markdown/posts/2022-08-05-updates.md
+++ b/markdown/posts/2022-08-05-updates.md
@@ -7,13 +7,13 @@ categories: updates
 
 ![PersonAtChalkboardIcon](https://mcusercontent.com/845c4ebabb5b5ae7a6372c715/images/0f8f9105-af2e-0ae6-60c4-c4edc9d05234.png)
 
-| **CURRENT STATUS**:
-| Current Version: **v3.102.0**
-| Next Scheduled Release: _19 August 2022_
-|
-| **CURRENT RELEASE HIGHLIGHTS**:
-|
-|We have just released the latest update to the code, **v3.102.0**, which is now available for download and installation. Along with some great new features for learners, this update includes major enhancements to the course visualization tools, another round of significant performance improvements, and a number of minor bugfixes, security and usability enhancements, and we recommend updating your systems at your earliest convenience.
+**CURRENT STATUS**:  
+Current Version: **v3.102.0**  
+Next Scheduled Release: _19 August 2022_
+
+**CURRENT RELEASE HIGHLIGHTS**:
+
+We have just released the latest update to the code, **v3.102.0**, which is now available for download and installation. Along with some great new features for learners, this update includes major enhancements to the course visualization tools, another round of significant performance improvements, and a number of minor bugfixes, security and usability enhancements, and we recommend updating your systems at your earliest convenience.
 
 **VISUALIZATIONS**
 This update includes major revisions and improvements to the course visualizations, improving the accuracy of aggregate counts, cleaning up the presentation, and generally making them more useful to you.

--- a/markdown/posts/2023-03-16-updates.md
+++ b/markdown/posts/2023-03-16-updates.md
@@ -7,11 +7,11 @@ categories: updates
 
 ![GI_Ilios_4_time_as_fast](https://gallery.mailchimp.com/845c4ebabb5b5ae7a6372c715/images/b6af0ee0-ff24-42bd-9018-9c46bda5aed7.jpg)
 
-| **CURRENT STATUS**:
-| Current Version: **v3.105.0**
-| Next Scheduled Release: _03 April 2023_
-|
-| **CURRENT RELEASE HIGHLIGHTS**:|
+**CURRENT STATUS**:  
+Current Version: **v3.105.0**  
+Next Scheduled Release: _03 April 2023_
+
+**CURRENT RELEASE HIGHLIGHTS**:
 
 Since the end of last year, we have been working on some major under-the-hood updates and revisions to the core code, to keep up with current libraries and package updates; more importantly, we have been refactoring critical components of our styling code, our search components, and of course our reporting tools, in line with the current roadmap. We will continue to place our focus on accessibility, sustainability, and reporting through the first half of this calendar year. In our most recently released update, **v3.105.0**, these begin to surface in more apparent ways.
 

--- a/markdown/posts/2023-08-04-updates.md
+++ b/markdown/posts/2023-08-04-updates.md
@@ -7,11 +7,11 @@ categories: updates
 
 ![image of man-at-whiteboard-icon](https://mcusercontent.com/845c4ebabb5b5ae7a6372c715/images/0f8f9105-af2e-0ae6-60c4-c4edc9d05234.png)
 
-| **CURRENT STATUS**:
-| Current Version: **v3.106.1**
-| Next Scheduled Release: _18 August 2023 (v3.107.0)_
-|
-| **CURRENT HIGHLIGHTS**:|
+**CURRENT STATUS**:  
+Current Version: **v3.106.1**  
+Next Scheduled Release: _18 August 2023 (v3.107.0)_
+
+**CURRENT HIGHLIGHTS**:
 
 Since our last update, the Ilios team has been busy with internal infrastructure updates here at our UCSF home, so progress on our roadmap has been a little slower than hoped. But the updates and upgrades elsewhere are now complete, and we are back to our focus on reporting tools for Ilios! We are also hoping to quickly complete the long awaited work providing for B2B/App-to-App service accounts in Ilios, to better and more securely leverage API connectivity and integrations with other external tools and systems.
 

--- a/markdown/posts/2023-12-04-updates.md
+++ b/markdown/posts/2023-12-04-updates.md
@@ -7,11 +7,11 @@ categories: updates
 
 ![darkened ilios logo](https://mcusercontent.com/845c4ebabb5b5ae7a6372c715/images/829d4dc8-8cb3-b5f0-2386-c4dd7823b356.png)
 
-| **CURRENT STATUS**:
-| Current Version: **v3.109.2**
-| Next Scheduled Release: _16 December 2023_
-|
-| **CURRENT HIGHLIGHTS**:|
+**CURRENT STATUS**:  
+Current Version: **v3.109.2**  
+Next Scheduled Release: _16 December 2023_
+
+**CURRENT HIGHLIGHTS**:
 
 What to say about 2023? We've achieved some notable milestones in work on Ilios, while others have had to be postponed or delayed, as we have addressed our own organizational change here at the University. As of this month, we have launched our app-specific B2B authentication token system, which should provide significantly more security and stability to integrated systems leveraging the Ilios API and data. We have completed the core code updates and enhancements necessary to launch our completely rewritten GraphQL-based reporting suite, which will now land early in 2024. We have made literally hundreds of updates and additions to the UI, in order to provide a more coherent, accessible, and consistent experience for all users.
 

--- a/markdown/posts/2023-12-22-updates.md
+++ b/markdown/posts/2023-12-22-updates.md
@@ -7,7 +7,6 @@ categories: updates
 
 ![Image of Charlie Brown and Snoopy from Charles Schulz's "Charlie Brown Christmas"](https://mcusercontent.com/845c4ebabb5b5ae7a6372c715/images/1466710a-f737-aee0-4b75-dcbbd18f417e.jpg)
 
-| **CURRENT STATUS**:
-| Current Version: **v3.110.0**
-| Next Scheduled Release: _**2024**, baby!_
-|
+**CURRENT STATUS**:  
+Current Version: **v3.110.0**  
+Next Scheduled Release: _**2024**, baby!_

--- a/markdown/posts/2024-04-08-updates.md
+++ b/markdown/posts/2024-04-08-updates.md
@@ -7,10 +7,9 @@ categories: updates
 
 ![Image of a solar eclipse. source: Nasa.gov](https://www.nasa.gov/wp-content/uploads/2017/08/469309main_20100711eclipse.jpg)
 
-| **CURRENT STATUS**:
-| Current Version: **v3.111.2**
-| Next Scheduled Release: _19 April, 2024_
-|
+**CURRENT STATUS**:  
+Current Version: **v3.111.2**  
+Next Scheduled Release: _19 April, 2024_
 
 While the sun may fall behind the moon's shadow today, Ilios, though a bit behind in our timeline progress, isn't falling behind anything dark!
 

--- a/markdown/posts/2024-07-25-updates.md
+++ b/markdown/posts/2024-07-25-updates.md
@@ -7,10 +7,9 @@ categories: updates
 
 ![Image of a GI with the tag "Ilios: 4x as fast"](https://gallery.mailchimp.com/845c4ebabb5b5ae7a6372c715/images/b6af0ee0-ff24-42bd-9018-9c46bda5aed7.jpg)
 
-| **CURRENT STATUS**:
-| Current Version: **v3.116.0**
-| Next Scheduled Release: _08 August, 2024_
-|
+**CURRENT STATUS**:  
+Current Version: **v3.116.0**  
+Next Scheduled Release: _08 August, 2024_
 
 While we continue to chug along here at Ilios headquarters, chipping away at our technical debt and housekeeping, we continue to tackle features we hope will set you up as users to be more effective in your educational work, and better prepared to support your curriculum governance and accreditation needs!
 

--- a/markdown/posts/2025-06-30-updates.md
+++ b/markdown/posts/2025-06-30-updates.md
@@ -10,9 +10,8 @@ description: >
 ![tada image](https://gallery.mailchimp.com/845c4ebabb5b5ae7a6372c715/images/21ebb36d-2da3-4b46-9294-1e962088a666.png)
 ![Image of Ilios logo](https://mcusercontent.com/845c4ebabb5b5ae7a6372c715/images/829d4dc8-8cb3-b5f0-2386-c4dd7823b356.png)
 
-| **CURRENT STATUS**:
-| Current Version: **v3.125.2**
-| Current API: _v3.12_
-| Current Frontend: **v43.9.3**
-| Next Scheduled Release: _14 July, 2025_
-|
+**CURRENT STATUS**:  
+Current Version: **v3.125.2**  
+Current API: _v3.12_  
+Current Frontend: **v43.9.3**  
+Next Scheduled Release: _14 July, 2025_


### PR DESCRIPTION
it appears that we were using the | character to indicate line breaks. that doesn't work anymore - the | gets rendered.

replacing it with the _proper_ line break, which is two blank spaces at the end of the line, as needed.